### PR TITLE
Update go bindings for 3.4.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: test deps download build clean docker
 
 # mlpack version to use.
-MLPACK_VERSION?=3.4.0
+MLPACK_VERSION?=3.4.1
 
 # armadillo version to use.
 ARMA_VERSION?=8.400.0


### PR DESCRIPTION
Update go-bindings as instructed in `re/deployment.md`.

(Release with tag; `v3.4.1`)